### PR TITLE
type should be set with req.types. not with the data.

### DIFF
--- a/src/world_model.cpp
+++ b/src/world_model.cpp
@@ -149,11 +149,6 @@ void WorldModel::update(const UpdateRequest& req)
         params.add(e->data());
         params.add(it->second);
 
-        tue::config::Reader r(params);
-        std::string type;
-        if (r.value("type", type, tue::config::OPTIONAL))
-            e->setType(type);
-
         e->setData(params);
     }
 


### PR DESCRIPTION
This allows the robocup plugin to set the correct type, which allows the use of dump-ed