### PR TITLE
support for .stl, .dae files as shapes

### DIFF
--- a/src/models/shape_loader.cpp
+++ b/src/models/shape_loader.cpp
@@ -427,7 +427,7 @@ geo::ShapePtr loadShape(const std::string& model_path, tue::config::Reader cfg,
                 geo::serialization::registerDeserializer<geo::Shape>();
                 shape = geo::serialization::fromFile(shape_path.string());
             }
-            else if (xt == ".3ds")
+            else if (xt == ".3ds" || ".stl" || ".dae")
             {
                 shape = geo::Importer::readMeshFile(shape_path.string());
             }


### PR DESCRIPTION
The ASSIMP library that supports this code allows for many formats of mesh files to be imported. So, a minor change has been made to allow .stl and .dae files which are common mesh file formats.