### PR TITLE
volumes returns a reference

### DIFF
--- a/include/ed/entity.h
+++ b/include/ed/entity.h
@@ -54,7 +54,7 @@ public:
     inline geo::ShapeConstPtr shape() const { return shape_; }
     void setShape(const geo::ShapeConstPtr& shape);
 
-    inline const std::map<std::string, geo::ShapeConstPtr> volumes() const { return volumes_; }
+    inline const std::map<std::string, geo::ShapeConstPtr>& volumes() const { return volumes_; }
     void addVolume(const std::string& volume_name, const geo::ShapeConstPtr& volume_shape) { volumes_[volume_name] = volume_shape; ++shape_revision_; }
     void removeVolume(const std::string& volume_name) { volumes_.erase(volume_name); ++shape_revision_; }
 


### PR DESCRIPTION
This prevents the need to create a copy of it, before you can use `find`. Otherwise the `end` will never be found, because it is the end of an other instance.