### PR TITLE
Update header

### DIFF
--- a/include/ed/plugin.h
+++ b/include/ed/plugin.h
@@ -1,7 +1,7 @@
 #ifndef ED_PLUGIN_H_
 #define ED_PLUGIN_H_
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #define ED_REGISTER_PLUGIN(Derived)  CLASS_LOADER_REGISTER_CLASS(Derived, ed::Plugin)
 
 #include <tue/config/configuration.h>


### PR DESCRIPTION
class_loader.h is deprecated in later versions and it in fact has only one line that includes class_loader.hpp