### PR TITLE
Fix closure of threads

### DIFF
--- a/src/plugin_container.cpp
+++ b/src/plugin_container.cpp
@@ -25,8 +25,8 @@ PluginContainer::~PluginContainer()
 {
     request_stop_ = true;
 
-//    if (thread_)
-//        thread_->join();
+    if (thread_)
+        thread_->join();
 
     plugin_.reset();
     delete class_loader_;
@@ -138,9 +138,12 @@ void PluginContainer::run()
     ros::Rate ir(innerloop_frequency);
     while(!request_stop_)
     {
-        while (!step())
+        if (!step())
+            // If not stepped, sleep short
             ir.sleep();
-        r.sleep();
+        else
+            // stepped, sleep normal
+            r.sleep();
     }
 
     is_running_ = false;


### PR DESCRIPTION
Threads kept running as they didn't stop if they didn't 'stepped' since last outer loop iteration. In that case the plugin would not check if stop was requested. But also never be stopped anymore. So thread would keep running. By also checking for a requested stop in the innerloop, a thread always stops nicely. So we can also wait again for the thread to join.